### PR TITLE
Fix issue with inline attachments

### DIFF
--- a/src/Mailer/Transport/MailgunTransport.php
+++ b/src/Mailer/Transport/MailgunTransport.php
@@ -250,7 +250,7 @@ class MailgunTransport extends AbstractTransport
         $attachments = [];
 
         foreach ($this->_cakeEmail->attachments() as $name => $file) {
-            if (isset($file['contentId'])) {
+            if (!empty($file['contentId'])) {
                 $attachments['inline'][] = ['filePath' => '@' . $file['file'], 'remoteName' => $file['contentId']];
             }
             else {

--- a/src/Mailer/Transport/MailgunTransport.php
+++ b/src/Mailer/Transport/MailgunTransport.php
@@ -199,7 +199,7 @@ class MailgunTransport extends AbstractTransport
 
         $attachments = $this->_processAttachments();
         if (!empty($attachments)) {
-            $this->_attachments['attachment'] = $attachments;
+            $this->_attachments = $attachments;
         }
 
         return $this->_sendMessage();
@@ -250,7 +250,12 @@ class MailgunTransport extends AbstractTransport
         $attachments = [];
 
         foreach ($this->_cakeEmail->attachments() as $name => $file) {
-            $attachments[] = ['filePath' => '@' . $file['file'], 'remoteName' => $name];
+            if (isset($file['contentId'])) {
+                $attachments['inline'][] = ['filePath' => '@' . $file['file'], 'remoteName' => $file['contentId']];
+            }
+            else {
+                $attachments['attachment'][] = ['filePath' => '@' . $file['file'], 'remoteName' => $name];
+            }
         }
 
         return $attachments;


### PR DESCRIPTION
Fixes the inline attachments from cakephp not being set into the correct property.
See more [here](https://github.com/mailgun/mailgun-php/blob/master/doc/attachments.md#inline-attachments).

This fixes #8.