### PR TITLE
Deprecation fixes since version 3.4.0

### DIFF
--- a/src/Mailer/Transport/MailgunTransport.php
+++ b/src/Mailer/Transport/MailgunTransport.php
@@ -189,7 +189,7 @@ class MailgunTransport extends AbstractTransport
             }
         }
 
-        $emailFormat = $this->_cakeEmail->emailFormat();
+        $emailFormat = $this->_cakeEmail->getEmailFormat();
 
         $this->_params['html'] = $this->_cakeEmail->message(Email::MESSAGE_HTML);
 
@@ -213,7 +213,7 @@ class MailgunTransport extends AbstractTransport
     protected function _sendMessage()
     {
         $this->_lastResponse = null;
-        $response = $this->_mgObject->sendMessage($this->config('domain'), $this->_params, $this->_attachments);
+        $response = $this->_mgObject->sendMessage($this->getConfig('domain'), $this->_params, $this->_attachments);
         $this->_reset();
         $this->_lastResponse = $response;
 
@@ -249,7 +249,7 @@ class MailgunTransport extends AbstractTransport
     {
         $attachments = [];
 
-        foreach ($this->_cakeEmail->attachments() as $name => $file) {
+        foreach ($this->_cakeEmail->getAttachments() as $name => $file) {
             if (!empty($file['contentId'])) {
                 $attachments['inline'][] = ['filePath' => '@' . $file['file'], 'remoteName' => $file['contentId']];
             }
@@ -268,29 +268,29 @@ class MailgunTransport extends AbstractTransport
      */
     protected function _setMgObject()
     {
-        if (empty($this->config('apiKey'))) {
+        if (empty($this->getConfig('apiKey'))) {
             throw new MissingCredentialsException(['API Key']);
         }
 
-        if (empty($this->config('domain'))) {
+        if (empty($this->getConfig('domain'))) {
             throw new MissingCredentialsException(['sending domain']);
         }
 
         if (!is_a($this->_mgObject, 'Mailgun')) {
-            if (!$this->config('isTest')) {
+            if (!$this->getConfig('isTest')) {
                 $client = new Client();
-                $this->_mgObject = new Mailgun($this->config('apiKey'), $client);
+                $this->_mgObject = new Mailgun($this->getConfig('apiKey'), $client);
             } else {
-                $this->_mgObject = new MailgunTest($this->config('apiKey'));
+                $this->_mgObject = new MailgunTest($this->getConfig('apiKey'));
             }
         }
 
-        if (!$this->config('ssl')) {
+        if (!$this->getConfig('ssl')) {
             $this->_mgObject->setSslEnabled(false);
         }
 
-        if ($this->config('apiVersion')) {
-            $this->_mgObject->setApiVersion($this->config('apiVersion'));
+        if ($this->getConfig('apiVersion')) {
+            $this->_mgObject->setApiVersion($this->getConfig('apiVersion'));
         } else {
             $this->_mgObject->setApiVersion($this->_apiVersion);
         }

--- a/tests/TestCase/Mailer/Transport/MailgunTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailgunTransportTest.php
@@ -52,17 +52,17 @@ class MailgunTransportTest extends TestCase
     public function testMissingApiKey()
     {
         $this->setExpectedException('MailgunEmail\Mailer\Exception\MissingCredentialsException');
-        $this->MailgunTransport->config([
+        $this->MailgunTransport->setConfig([
             'apiKey' => 'My-Super-Awesome-API-Key',
             'domain' => ''
         ]);
 
         $email = new Email();
-        $email->transport($this->MailgunTransport);
-        $email->from(['sender@test.mailgun.org' => 'Mailgun Test'])
-                ->to('test@test.mailgun.org')
-                ->subject('This is test subject')
-                ->emailFormat('text')
+        $email->setTransport($this->MailgunTransport);
+        $email->setFrom(['sender@test.mailgun.org' => 'Mailgun Test'])
+                ->setTo('test@test.mailgun.org')
+                ->setSubject('This is test subject')
+                ->setEmailFormat('text')
                 ->send('Testing Maingun');
     }
 
@@ -74,17 +74,17 @@ class MailgunTransportTest extends TestCase
     public function testMissingDomain()
     {
         $this->setExpectedException('MailgunEmail\Mailer\Exception\MissingCredentialsException');
-        $this->MailgunTransport->config([
+        $this->MailgunTransport->setConfig([
             'apiKey' => '',
             'domain' => ''
         ]);
 
         $email = new Email();
-        $email->transport($this->MailgunTransport);
-        $email->from(['sender@test.mailgun.org' => 'Mailgun Test'])
-                ->to('test@test.mailgun.org')
-                ->subject('This is test subject')
-                ->emailFormat('text')
+        $email->setTransport($this->MailgunTransport);
+        $email->setFrom(['sender@test.mailgun.org' => 'Mailgun Test'])
+                ->setTo('test@test.mailgun.org')
+                ->setSubject('This is test subject')
+                ->setEmailFormat('text')
                 ->send('Testing Maingun');
     }
 
@@ -96,13 +96,13 @@ class MailgunTransportTest extends TestCase
     public function testMissingRequiredFields()
     {
         $this->setExpectedException('BadMethodCallException');
-        $this->MailgunTransport->config($this->validConfig);
+        $this->MailgunTransport->setConfig($this->validConfig);
 
         $email = new Email();
-        $email->transport($this->MailgunTransport);
-        $email->to('test@test.mailgun.org')
-                ->subject('This is test subject')
-                ->emailFormat('text')
+        $email->setTransport($this->MailgunTransport);
+        $email->setTo('test@test.mailgun.org')
+                ->setSubject('This is test subject')
+                ->setEmailFormat('text')
                 ->send('Testing Maingun');
     }
 
@@ -113,14 +113,14 @@ class MailgunTransportTest extends TestCase
      */
     public function testSend()
     {
-        $this->MailgunTransport->config($this->validConfig);
+        $this->MailgunTransport->setConfig($this->validConfig);
 
         $email = new Email();
-        $email->transport($this->MailgunTransport);
-        $result = $email->from('sender@test.mailgun.org')
-                ->to('test@test.mailgun.org')
-                ->subject('This is test subject')
-                ->emailFormat('text')
+        $email->setTransport($this->MailgunTransport);
+        $result = $email->setFrom('sender@test.mailgun.org')
+                ->setTo('test@test.mailgun.org')
+                ->setSubject('This is test subject')
+                ->setEmailFormat('text')
                 ->send('Testing Maingun');
         $this->assertEquals("test.mailgun.org/messages", $result->http_endpoint_url);
     }
@@ -135,15 +135,15 @@ class MailgunTransportTest extends TestCase
         $mailgunTransport = $this->getMockBuilder('MailgunEmail\Mailer\Transport\MailgunTransport')
             ->setMethods(['_reset'])
             ->getMock();
-        $mailgunTransport->config($this->validConfig);
+        $mailgunTransport->setConfig($this->validConfig);
 
         $email = new Email();
-        $email->transport($mailgunTransport);
-        $result = $email->from('sender@test.mailgun.org')
-                ->to('test@test.mailgun.org')
-                ->subject('This is test subject')
-                ->emailFormat('both')
-                ->attachments([
+        $email->setTransport($mailgunTransport);
+        $result = $email->setFrom('sender@test.mailgun.org')
+                ->setTo('test@test.mailgun.org')
+                ->setSubject('This is test subject')
+                ->setEmailFormat('both')
+                ->setAttachments([
                     'cake_icon.png' => TESTS . DS . 'TestAssets' . DS . 'cake.icon.png',
                     'cake.power.gif' => ['file' => TESTS . DS . 'TestAssets' . DS . 'cake.power.gif', 'contentId' => 'CakePower'],
                 ])
@@ -175,13 +175,13 @@ class MailgunTransportTest extends TestCase
         $mailgunTransport = $this->getMockBuilder('MailgunEmail\Mailer\Transport\MailgunTransport')
             ->setMethods(['_reset'])
             ->getMock();
-        $mailgunTransport->config($this->validConfig);
+        $mailgunTransport->setConfig($this->validConfig);
 
         $email = new Email();
-        $email->transport($mailgunTransport);
-        $result = $email->from('sender@test.mailgun.org')
-                ->to('test@test.mailgun.org')
-                ->subject('This is test subject')
+        $email->setTransport($mailgunTransport);
+        $result = $email->setFrom('sender@test.mailgun.org')
+                ->setTo('test@test.mailgun.org')
+                ->setSubject('This is test subject')
                 ->addHeaders(['o:tag' => 'testing', 'o:tracking' => 'yes'])
                 ->addHeaders(['v:custom-data' => json_encode(['foo' => 'bar'])])
                 ->send('Testing Maingun');


### PR DESCRIPTION
Deprecated since version 3.4.0: Use setFrom(), setTo(), setCc() , setBcc() and setSubject() and many more.
https://book.cakephp.org/3.0/en/core-libraries/email.html