### PR TITLE
Support raw binary attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
     ->setAttachments([
         'cake_icon1.png' => Configure::read('App.imageBaseUrl') . 'cake.icon.png',
         'cake_icon2.png' => ['file' => Configure::read('App.imageBaseUrl') . 'cake.icon.png', 'contentId' => 'cake.icon.png'],
+        'myfile.txt' => ['data' => 'c29tZSB0ZXh0', 'mimetype' => 'text/plain'], // c29tZSB0ZXh0 = base64_encode('some text')
         WWW_ROOT . 'favicon.ico'
     ])
     ->setSubject('Email from CakePHP Mailgun plugin')

--- a/src/Mailer/Transport/MailgunTransport.php
+++ b/src/Mailer/Transport/MailgunTransport.php
@@ -133,11 +133,11 @@ class MailgunTransport extends AbstractTransport
 
         $attachments = $email->getAttachments();
         if (!empty($attachments)) {
-            foreach ($attachments as $attachment) {
+            foreach ($attachments as $fileName => $attachment) {
                 if (empty($attachment['contentId'])) {
-                    $file = $this->_formData->addFile('attachment', fopen($attachment['file'], 'r'));
+                    $file = $this->_addFile('attachment', $attachment, $fileName);
                 } else {
-                    $file = $this->_formData->addFile('inline', fopen($attachment['file'], 'r'));
+                    $file = $this->_addFile('inline', $attachment, $fileName);
                     $file->contentId($attachment['contentId']);
                 }
                 $file->disposition('attachment');
@@ -154,6 +154,28 @@ class MailgunTransport extends AbstractTransport
         $this->_reset();
 
         return $res;
+    }
+
+    /**
+     * Add file attachment to email.
+     *
+     * @param string $partName Name of the file part
+     * @param array $attachment Attachment as initially set via setAttachment()
+     * @param string $fileName Desired filename of the attachment
+     * @return \Cake\Http\Client\FormDataPart
+     */
+    protected function _addFile($partName, $attachment, $fileName = '')
+    {
+        if (isset($attachment['file'])) {
+            $file = $this->_formData->addFile($partName, fopen($attachment['file'], 'r'));
+        } else {
+            $file = $this->_formData->newPart($partName, base64_decode($attachment['data']));
+            $file->type($attachment['mimetype']);
+            $file->filename($fileName);
+            $this->_formData->add($file);
+        }
+
+        return $file;
     }
 
     /**

--- a/tests/TestCase/Mailer/Transport/MailgunTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailgunTransportTest.php
@@ -129,6 +129,27 @@ class MailgunTransportTest extends TestCase
         $this->assertStringEndsWith("--$boundary--", rtrim($reqDataString));
     }
 
+    public function testRawBinaryAttachments()
+    {
+        $this->_setEmailConfig();
+        $email = new Email();
+        $email->setProfile(['transport' => 'mailgun']);
+        $res = $email->setFrom('from@example.com')
+            ->setTo('to@example.com')
+            ->setAttachments([
+                'myfile.txt' => ['data' => 'c29tZSB0ZXh0', 'mimetype' => 'text/plain'], // c29tZSB0ZXh0 = base64_encode('some text')
+            ])
+            ->setSubject('Email from CakePHP Mailgun plugin')
+            ->send('Hello there, <br> This is an email from CakePHP Mailgun Email plugin.');
+
+        $reqData = $res['reqData'];
+        $boundary = $reqData->boundary();
+        $reqDataString = (string)$reqData;
+        $this->assertNotEmpty($reqDataString);
+        $this->assertStringStartsWith("--$boundary", $reqDataString);
+        $this->assertStringEndsWith("--$boundary--", rtrim($reqDataString));
+    }
+
     public function testSetOption()
     {
         $this->_setEmailConfig();


### PR DESCRIPTION
This PR adds support for cases where raw binary attachments need to be used instead of attaching files from the local file system.  Examples include:

* Generating a PDF and attaching its content.
* Pulling a file from Amazon S3 and attaching its raw content without saving the file on the local fule system.
* etc.