### PR TITLE
Better Transport and new MailgunEmail class

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This plugin provides email delivery using [Mailgun API](https://www.mailgun.com/
 
 This plugin has the following requirements:
 
-* CakePHP 3.4.0 or greater.
+* CakePHP 3.7.0 or greater.
 * PHP 5.6 or greater.
 
 ## Installation
@@ -26,10 +26,6 @@ composer require narendravaghela/cakephp-mailgun
 ```
 
 After installation, [Load the plugin](https://book.cakephp.org/3.0/en/plugins.html#loading-a-plugin)
-```php
-Plugin::load('Mailgun');
-```
-Or, you can load the plugin using the shell command
 ```sh
 $ bin/cake plugin load Mailgun
 ```
@@ -73,7 +69,7 @@ And create new delivery profile in `Email` settings.
 You can now simply use the CakePHP's `Email` to send an email via Mailgun.
 
 ```php
-$email = new Email('mailgun');
+$email = new MailgunEmail();
 $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
     ->setTo('foo@example.com')
     ->addCc('john@example.com')
@@ -90,7 +86,7 @@ You can also use more options to customise the email message.
 You can pass your own headers. It must be prefixed with "X-". Use the default `Email::setHeaders` method like,
 
 ```php
-$email = new Email('mailgun');
+$email = new MailgunEmail();
 $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
     ->setTo('foo@example.com')
     ->setHeaders([
@@ -105,7 +101,7 @@ $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
 Set your attachments using `Email::setAttachments` method.
 
 ```php
-$email = new Email('mailgun');
+$email = new MailgunEmail();
 $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
     ->setTo('foo@example.com')
     ->setAttachments([
@@ -124,7 +120,7 @@ $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
 You can use the your CakePHP's layout and template as your email's HTML body.
 
 ```php
-$email = new Email('mailgun');
+$email = new MailgunEmail();
 $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
 	->setTo('foo@example.com')
 	->setLayout('newsletter') // in src/Template/Layout/Email/html/newsletter.ctp
@@ -137,7 +133,7 @@ $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
 Mailgun provides an option to send email to a group of recipients through a single API call. Simple, add multiple recipients using `Email::setTo()` like,
 
 ```php
-$email = new Email('mailgun');
+$email = new MailgunEmail();
 $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
     ->setTo('foo@example.com')
     ->addTo(['bar@example.com', 'john@example.com']) // alternate way to add multiple
@@ -146,7 +142,7 @@ $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
 ```
 
 #### Recipient Variables
-In case of sending batch emails, also use Recipient Variables. Otherwise, all recipients’ email addresses will show up in the to field for each recipient. To do so, you need to get the transport instance by `getTransport()` and call `setRecipientVars()` method.
+In case of sending batch emails, also use Recipient Variables. Otherwise, all recipients’ email addresses will show up in the to field for each recipient. To do so, you need to call `MailgunEmail->setRecipientVars()` method.
 This also allows you to replace email content with recipient specific data. E.g. you would like to say recipient's name in the email body.
 
 ```php
@@ -156,46 +152,41 @@ $recipientVars = [
 	'john@example.com' => ['name' => 'John', 'city' => 'Toronto']
 ];
 
-$email = new Email('mailgun');
-$emailInstance = $email->getTransport();
-$emailInstance->setRecipientVars($recipientVars);
+$email = new MailgunEmail();
 $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
     ->setTo('foo@example.com')
     ->addTo(['bar@example.com', 'john@example.com'])
+    ->setRecipientVars($recipientVars)
     ->setSubject('Hello %recipient.name%, welcome to %recipient.city%!')
     ->send('Message from CakePHP Mailgun plugin');
 ```
 > The keys of recipient variables must be the email address of recipients. Once set, you can use the %recipient.varname% in subject or body.
 
 ### Custom Message Data
-You can attache some data to message. The data can be used in any webhook events related to the email. Use `setCustomMessageData()` method and pass the required data. Read [this](https://documentation.mailgun.com/en/latest/user_manual.html#attaching-data-to-messages) for more details.
+You can attache some data to message. The data can be used in any webhook events related to the email. Use `setMailgunVars()` method and pass the required data. Read [this](https://documentation.mailgun.com/en/latest/user_manual.html#attaching-data-to-messages) for more details.
 
 ```php
-$email = new Email('mailgun');
-$emailInstance = $email->getTransport();
-$emailInstance->setCustomMessageData('my-custom-data', ["my_message_id" => 123]);
-// or
-$emailInstance->setCustomMessageData('my-custom-data', '{"my_message_id": 123}');
-$email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
+$email = new MailgunEmail();
+$email->setMailgunVars('my-custom-data', ["my_message_id" => 123])
+    ->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
     ->setTo('foo@example.com')
     ->addTo(['bar@example.com', 'john@example.com'])
     ->setSubject('Hello %recipient.name%, welcome to %recipient.city%!')
     ->send('Message from CakePHP Mailgun plugin');
 ```
 
-> The data must be a valid `JSON` string or an `Array`.
+> The data must be an `Array`.
 
 ### Additional Options
-You can also set a few more options in you email request like tagging, delivery time, test mode etc. For this, you need to use the transport instance and `setOption()` method. Read [this](https://documentation.mailgun.com/en/latest/api-sending.html#sending) for detailed information.
+You can also set a few more options in you email request like tagging, delivery time, test mode etc. For this, you need to use the `MailgunEmail->testMode()` method. Read [this](https://documentation.mailgun.com/en/latest/api-sending.html#sending) for detailed information.
 
 #### Tagging
-Tags are more in Mailgun's tracking features. You can assign multipe tags to email. Use `tag` as option name.
+Tags are more in Mailgun's tracking features. You can assign multiple tags to email. Use `MailgunEmail->setTags()` as option name.
 
 ```php
-$email = new Email('mailgun');
-$emailInstance = $email->getTransport();
-$emailInstance->setOption('tag', 'monthly newsletter');
-$emailInstance->setOption('tag', ['newsletter', 'monthly newsletter']); // if multiple
+$email = new MailgunEmail();
+$email->setTags('monthly newsletter');
+$email->setTags(['newsletter', 'monthly newsletter']); // if multiple
 $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
     ->setTo('foo@example.com')
     ->addTo(['bar@example.com', 'john@example.com'])
@@ -204,84 +195,73 @@ $email->setFrom(['you@yourdomain.com' => 'CakePHP Mailgun'])
 ```
 
 #### DKIM signature
-You can enable/disable DKIM signature validation. Set `yes` or `no` as a value of `dkim` option.
+You can enable/disable DKIM signature validation. Use `MailgunEmail->enableDkim()` 
 
 ```php
-$email = new Email('mailgun');
-$emailInstance = $email->getTransport();
-$emailInstance->setOption('dkim', 'yes');
+$email = new MailgunEmail();
+$email->enableDkim();
 ```
+> Pass `true` or `false`. Default `true`.
 
 #### Delivery Time
-You can set the desired time of email message delivety. Use `deliverytime` as option name.
+You can set the desired time of email message delivety. Use `MailgunEmail->deliverBy()`.
 
 ```php
-$email = new Email('mailgun');
-$emailInstance = $email->getTransport();
-$emailInstance->setOption('deliverytime', strtotime('+1 day'));
+$email = new MailgunEmail();
+$email->deliverBy(new \DateTime(strtotime('+1 day')));
 ```
 
 > Note: Messages can be scheduled for a maximum of 3 days in the future as per Mailgun documentation. Pass a valid unix timestamp as a value.
 
 #### Test Mode
-Enables sending in test mode. Use `testmode` as option name.
+Enables sending in test mode. Use `MailgunEmail->testMode()`
 
 ```php
-$email = new Email('mailgun');
-$emailInstance = $email->getTransport();
-$emailInstance->setOption('testmode', 'yes');
+$email = new MailgunEmail();
+$email->testMode();
 ```
-
-> Pass `yes` if needed.
+> Pass `true` or `false`. Default `false`.
 
 #### Tracking Clicks
-Enables/Disables click tracking on a per-message basis. Use `tracking-clicks` as option name.
+Enables/Disables click tracking on a per-message basis. Use `MailgunEmail->trackClicks`.
 
 ```php
-$email = new Email('mailgun');
-$emailInstance = $email->getTransport();
-$emailInstance->setOption('tracking-clicks', 'yes');
+$email = new MailgunEmail();
+$email->trackClicks();
 ```
-
-> Pass `yes` or `no`.
+> Pass `true` or `false`. Default `true`.
 
 #### Tracking Opens
-Enables/Disables click tracking on a per-message basis. Use `tracking-opens` as option name.
+Enables/Disables click tracking on a per-message basis. Use `MailgunEmail->trackOpens`.
 
 ```php
-$email = new Email('mailgun');
-$emailInstance = $email->getTransport();
-$emailInstance->setOption('tracking-opens', 'yes');
+$email = new MailgunEmail();
+$email->trackClicks();
 ```
-
-> Pass `yes` or `no`.
+> Pass `true` or `false`. Default `true`.
 
 #### Require TLS
-Sets the email sending over TLS connection. Use `require-tls` as option name.
+Sets the email sending over TLS connection. Use `MailgunEmail->requireTls()`.
 
 ```php
-$email = new Email('mailgun');
-$emailInstance = $email->getTransport();
-$emailInstance->setOption('require-tls', 'True');
+$email = new MailgunEmail();
+$email->requireTls(true);
 ```
-
-> Pass `True` or `False`. Default `False`.
+> Pass `true` or `false`. Default `false`.
 
 #### Skip Verification
-Enables/Disable the hostname and certificate verification to establish TLS connection. Use `skip-verification` as option name.
+Enables/Disable the hostname and certificate verification to establish TLS connection. Use `MailgunEmail->skipVerification()`
 
 ```php
-$email = new Email('mailgun');
-$emailInstance = $email->getTransport();
-$emailInstance->setOption('skip-verification', 'True');
+$email = new MailgunEmail();
+$email->skipVerification();
 ```
-
-> Pass `True` or `False`. Default `False`.
+> Pass `true` or `false`. Default `false`.
 
 ## Versions
 This plugin has several releases. Please use the appropriate version by downloading a tag, or checking out the correct branch.
 
- - `3.x` are compatible with CakePHP 3.4.x and greater. It is now under active development.
+ - `3.x` are compatible with CakePHP 3.7.x and greater. It is now under active development.
  - `1.x` are compatible with older CakePHP 3 releases. Only bug fixes will be applied to this.
 
 ## Contributing

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "issues": "https://github.com/narendravaghela/cakephp-mailgun/issues"
     },
     "require": {
-        "cakephp/cakephp": "^3.7.0"
+        "cakephp/cakephp": "^3.7.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.14|^6.0",

--- a/src/Mailer/MailgunEmail.php
+++ b/src/Mailer/MailgunEmail.php
@@ -73,7 +73,7 @@ class MailgunEmail extends CoreEmail
         if ($time->diff(new \DateTime())->days > 3) {
             throw new MailgunApiException('Delivery date can only be max of 3 days in the future.');
         }
-        $this->addHeaders(['X-Mailgun-Deliver-By' => $time->format(\DateTimeInterface::RFC822)]);
+        $this->addHeaders(['X-Mailgun-Deliver-By' => $time->format(\DateTimeInterface::RFC2822)]);
 
         return $this;
     }

--- a/src/Mailer/MailgunEmail.php
+++ b/src/Mailer/MailgunEmail.php
@@ -6,6 +6,7 @@ use Mailgun\Mailer\Exception\MailgunApiException;
 
 class MailgunEmail extends CoreEmail
 {
+    const TIMEFORMAT = 'D, d M Y H:i:s O';
 
     /**
      * Constructor
@@ -73,7 +74,7 @@ class MailgunEmail extends CoreEmail
         if ($time->diff(new \DateTime())->days > 3) {
             throw new MailgunApiException('Delivery date can only be max of 3 days in the future.');
         }
-        $this->addHeaders(['X-Mailgun-Deliver-By' => $time->format(\DateTimeInterface::RFC2822)]);
+        $this->addHeaders(['X-Mailgun-Deliver-By' => $time->format(self::TIMEFORMAT)]);
 
         return $this;
     }

--- a/src/Mailer/MailgunEmail.php
+++ b/src/Mailer/MailgunEmail.php
@@ -38,7 +38,7 @@ class MailgunEmail extends CoreEmail
             throw new MailgunApiException('You can only set a max of 3 tags.');
         }
 
-        $this->addHeaders(['X-Mailgun-Tag' => implode(',', $tags)]);
+        $this->addHeaders(['X-Mailgun-Tag' => json_encode($tags)]);
 
         return $this;
     }

--- a/src/Mailer/MailgunEmail.php
+++ b/src/Mailer/MailgunEmail.php
@@ -49,7 +49,7 @@ class MailgunEmail extends CoreEmail
      *
      * @return $this
      */
-    public function enableDkim(bool $enable = true)
+    public function enableDkim($enable = true)
     {
         $this->addHeaders(['X-Mailgun-Dkim' => $enable ? 'yes' : 'no']);
 
@@ -103,7 +103,7 @@ class MailgunEmail extends CoreEmail
      *
      * @see https://documentation.mailgun.com/en/latest/user_manual.html#tracking-messages
      */
-    public function enableTracking(bool $track = true)
+    public function enableTracking($track = true)
     {
         $this->addHeaders(['X-Mailgun-Track' => $track ? 'yes' : 'no']);
 

--- a/src/Mailer/MailgunEmail.php
+++ b/src/Mailer/MailgunEmail.php
@@ -1,0 +1,214 @@
+<?php
+namespace Mailgun\Mailer;
+
+use Cake\Mailer\Email as CoreEmail;
+use Mailgun\Mailer\Exception\MailgunApiException;
+
+class MailgunEmail extends CoreEmail
+{
+
+    /**
+     * Constructor
+     *
+     * @param array $config Configuration options.
+     */
+    public function __construct($config = null)
+    {
+        parent::__construct($config);
+
+        $this->setProfile(['transport' => 'mailgun']);
+    }
+
+    /**
+     * Sets the Mailgun Tags for this message.
+     *
+     * @param array|string $tags Array of tags.
+     *
+     * @return $this
+     *
+     * @see https://documentation.mailgun.com/en/latest/user_manual.html#tagging
+     */
+    public function setTags($tags)
+    {
+        if (is_string($tags)) {
+            $tags = explode(',', $tags);
+        }
+        if (count($tags) > 3) {
+            throw new MailgunApiException('You can only set a max of 3 tags.');
+        }
+
+        $this->addHeaders(['X-Mailgun-Tag' => implode(',', $tags)]);
+
+        return $this;
+    }
+
+    /**
+     * Enables/disables DKIM signatures on a per-message basis.
+     *
+     * @param bool $enable True to enable DKIM, False to disable DKIM.
+     *
+     * @return $this
+     */
+    public function enableDkim(bool $enable = true)
+    {
+        $this->addHeaders(['X-Mailgun-Dkim' => $enable ? 'yes' : 'no']);
+
+        return $this;
+    }
+
+    /**
+     * Desired time of delivery.
+     *
+     * @param \DateTime $time Time to deliver message
+     *
+     * @return $this
+     *
+     * @see https://documentation.mailgun.com/en/latest/user_manual.html#id8
+     * @see https://documentation.mailgun.com/en/latest/api-intro.html#date-format
+     *
+     * @throws \Exception Emits Exception if error encountered.
+     */
+    public function deliverBy($time)
+    {
+        if ($time->diff(new \DateTime())->days > 3) {
+            throw new MailgunApiException('Delivery date can only be max of 3 days in the future.');
+        }
+        $this->addHeaders(['X-Mailgun-Deliver-By' => $time->format(\DateTimeInterface::RFC822)]);
+
+        return $this;
+    }
+
+    /**
+     * Enables sending in test mode.
+     *
+     * @param bool $drop True to drop message, False to send message.
+     *
+     * @return $this
+     *
+     * @see https://documentation.mailgun.com/en/latest/user_manual.html#manual-testmode
+     */
+    public function testMode($drop = true)
+    {
+        $this->addHeaders(['X-Mailgun-Drop-Message' => $drop ? 'yes' : 'no']);
+
+        return $this;
+    }
+
+    /**
+     * Togfgles tracking on a per-message basis
+     *
+     * @param bool $track True to track message, False to not track message.
+     *
+     * @return $this
+     *
+     * @see https://documentation.mailgun.com/en/latest/user_manual.html#tracking-messages
+     */
+    public function enableTracking(bool $track = true)
+    {
+        $this->addHeaders(['X-Mailgun-Track' => $track ? 'yes' : 'no']);
+
+        return $this;
+    }
+
+    /**
+     * Toggles click tracking on a per-message basis.
+     *
+     * @param bool|null $track True to track click, False to not track click, null to set HTML only click tracking.
+     *
+     * @return $this
+     *
+     * @see https://documentation.mailgun.com/en/latest/user_manual.html#tracking-messages
+     */
+    public function trackClicks($track = null)
+    {
+        if ($track === null) {
+            $this->addHeaders(['X-Mailgun-Track-Clicks' => 'htmlonly']);
+        } else {
+            $this->addHeaders(['X-Mailgun-Track-Clicks' => $track ? 'yes' : 'no']);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Toggles open tracking on a per-message basis.
+     *
+     * @param bool $track True to enable open tracking, False to disable open tracking.
+     *
+     * @return $this
+     *
+     * @see https://documentation.mailgun.com/en/latest/user_manual.html#tracking-messages
+     */
+    public function trackOpens($track = false)
+    {
+        $this->addHeaders(['X-Mailgun-Track-Opens' => $track ? 'yes' : 'no']);
+
+        return $this;
+    }
+
+    /**
+     * Require the message to be sent via TLS
+     *
+     * @param bool $tls True to require the message to be sent via TLS, False to try TLS first and then downgrade to
+     * plain text.
+     *
+     * @return $this
+     *
+     * @see https://documentation.mailgun.com/en/latest/user_manual.html#tls-sending
+     */
+    public function requireTls($tls = false)
+    {
+        $this->addHeaders(['X-Mailgun-Require-TLS' => $tls ? 'true' : 'false']);
+
+        return $this;
+    }
+
+    /**
+     * Verify TLS certificate
+     *
+     * @param bool $verify True to not verify the certificate and hostname when sending, False to verify the certificate
+     * and hostname if the certifiate and hostname cannot be verified a TLS connection will not be established.
+     *
+     * @return $this
+     *
+     * @see https://documentation.mailgun.com/en/latest/user_manual.html#tls-sending
+     */
+    public function skipVerification($verify = false)
+    {
+        $this->addHeaders(['X-Mailgun-Skip-Verification' => $verify ? 'true' : 'false']);
+
+        return $this;
+    }
+
+    /**
+     * Variables to substitute when sending batched messages.
+     *
+     * @param array $vars Array of variables to set. The first level key must be the recipient email address.
+     *
+     * @return $this
+     *
+     * @see https://documentation.mailgun.com/en/latest/user_manual.html#batch-sending
+     */
+    public function setRecipientVars(array $vars)
+    {
+        $this->addHeaders(['X-Mailgun-Recipient-Variables' => json_encode($vars)]);
+
+        return $this;
+    }
+
+    /**
+     * Attach custom data to the message.
+     *
+     * @param array $vars Array of data to attach to the message.
+     *
+     * @return $this
+     *
+     * @see https://documentation.mailgun.com/en/latest/user_manual.html#manual-customdata
+     */
+    public function setMailgunVars(array $vars)
+    {
+        $this->addHeaders(['X-Mailgun-Variables' => $vars]);
+
+        return $this;
+    }
+}

--- a/src/Mailer/Transport/MailgunTransport.php
+++ b/src/Mailer/Transport/MailgunTransport.php
@@ -415,6 +415,15 @@ class MailgunTransport extends AbstractTransport
                             $this->_formData->add("{$this->_varPrefix}$k", $v);
                         }
                     }
+                } elseif ($header === $this->_mailgunHeaderPrefix . '-Tag') {
+                    $var = $this->_mailgunHeaders[$header];
+                    if (is_string($value)) {
+                        $value = json_decode($value);
+                        if (json_last_error() === JSON_ERROR_NONE && is_string($value)) {
+                            $value = explode(',', $value);
+                        }
+                    }
+                    $this->_formData->add("{$this->_optionPrefix}$var", $value);
                 } else {
                     $var = $this->_mailgunHeaders[$header];
                     $this->_formData->add("{$this->_optionPrefix}$var", $value);

--- a/src/Mailer/Transport/MailgunTransport.php
+++ b/src/Mailer/Transport/MailgunTransport.php
@@ -397,6 +397,8 @@ class MailgunTransport extends AbstractTransport
      * Process the Email headers and covert them to mailgun form parts
      *
      * @param Email $email Email to work with
+     *
+     * @return void
      */
     protected function _processHeaders(Email $email)
     {

--- a/tests/TestCase/Mailer/MailgunEmailTest.php
+++ b/tests/TestCase/Mailer/MailgunEmailTest.php
@@ -93,7 +93,7 @@ class MailgunEmailTest extends TestCase
         $this->Email->deliverBy($time);
 
         $headers = $this->Email->getHeaders(['X-Mailgun-Deliver-By']);
-        $expected = $time->format(\DateTimeInterface::RFC2822);
+        $expected = $time->format(MailgunEmail::TIMEFORMAT);
 
         $this->assertEquals($expected, $headers['X-Mailgun-Deliver-By']);
     }

--- a/tests/TestCase/Mailer/MailgunEmailTest.php
+++ b/tests/TestCase/Mailer/MailgunEmailTest.php
@@ -36,10 +36,10 @@ class MailgunEmailTest extends TestCase
 
     public function testTagsArray()
     {
-        $this->Email->setTags(['tag1', 'tag2', 'tag3']);
+        $tags = ['tag1', 'tag2', 'tag3'];
+        $this->Email->setTags($tags);
         $headers = $this->Email->getHeaders(['X-Mailgun-Tag']);
-        $expected = 'tag1,tag2,tag3';
-        $this->assertEquals($expected, $headers['X-Mailgun-Tag']);
+        $this->assertEquals(json_encode($tags), $headers['X-Mailgun-Tag']);
     }
 
     public function testTagsArrayMoreThanThree()
@@ -54,7 +54,7 @@ class MailgunEmailTest extends TestCase
     {
         $this->Email->setTags('tag1,tag2,tag3');
         $headers = $this->Email->getHeaders(['X-Mailgun-Tag']);
-        $expected = 'tag1,tag2,tag3';
+        $expected = json_encode(['tag1', 'tag2', 'tag3']);
 
         $this->assertEquals($expected, $headers['X-Mailgun-Tag']);
     }

--- a/tests/TestCase/Mailer/MailgunEmailTest.php
+++ b/tests/TestCase/Mailer/MailgunEmailTest.php
@@ -1,0 +1,276 @@
+<?php
+namespace Mailgun\Test\TestCase\Mailer;
+
+use Cake\Core\Configure;
+use Cake\Mailer\TransportFactory;
+use Cake\TestSuite\TestCase;
+use Mailgun\Mailer\MailgunEmail;
+
+class MailgunEmailTest extends TestCase
+{
+    /**
+     * @var MailgunEmail
+     */
+    public $Email;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Configure::write('DebugKit.panels', ['DebugKit.Mail' => false]);
+        $this->_setEmailConfig();
+        $this->Email = new MailgunEmail();
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->Email);
+
+        parent::tearDown();
+    }
+
+    public function testTagsArray()
+    {
+        $this->Email->setTags(['tag1', 'tag2', 'tag3']);
+        $headers = $this->Email->getHeaders(['X-Mailgun-Tag']);
+        $expected = 'tag1,tag2,tag3';
+        $this->assertEquals($expected, $headers['X-Mailgun-Tag']);
+    }
+
+    public function testTagsArrayMoreThanThree()
+    {
+        $this->expectException('Mailgun\Mailer\Exception\MailgunApiException');
+        $this->expectExceptionMessage('You can only set a max of 3 tags.');
+
+        $this->Email->setTags(['tag1', 'tag2', 'tag3', 'tag4']);
+    }
+
+    public function testTagString()
+    {
+        $this->Email->setTags('tag1,tag2,tag3');
+        $headers = $this->Email->getHeaders(['X-Mailgun-Tag']);
+        $expected = 'tag1,tag2,tag3';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Tag']);
+    }
+
+    public function testTagsStringMoreThanThree()
+    {
+        $this->expectException('Mailgun\Mailer\Exception\MailgunApiException');
+        $this->expectExceptionMessage('You can only set a max of 3 tags.');
+
+        $this->Email->setTags('tag1,tag2,tag3,tag4');
+    }
+
+    public function testEnableDkimTrue()
+    {
+        $this->Email->enableDkim();
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Dkim']);
+        $expected = 'yes';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Dkim']);
+    }
+
+    public function testEnableDkimFalse()
+    {
+        $this->Email->enableDkim(false);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Dkim']);
+        $expected = 'no';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Dkim']);
+    }
+
+    public function testDeliverBy()
+    {
+        $time = new \DateTime();
+        $this->Email->deliverBy($time);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Deliver-By']);
+        $expected = $time->format(\DateTimeInterface::RFC822);
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Deliver-By']);
+    }
+
+    public function testDeliverByFourDaysInFuture()
+    {
+        $this->expectException('Mailgun\Mailer\Exception\MailgunApiException');
+        $this->expectExceptionMessage('Delivery date can only be max of 3 days in the future.');
+
+        $time = (new \DateTime())->add(new \DateInterval('P4D'));
+        $this->Email->deliverBy($time);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Deliver-By']);
+    }
+
+    public function testTestModeTrue()
+    {
+        $this->Email->testMode();
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Drop-Message']);
+        $expected = 'yes';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Drop-Message']);
+    }
+
+    public function testTestModeFalse()
+    {
+        $this->Email->testMode(false);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Drop-Message']);
+        $expected = 'no';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Drop-Message']);
+    }
+
+    public function testTrackTrue()
+    {
+        $this->Email->enableTracking();
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Track']);
+        $expected = 'yes';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Track']);
+    }
+
+    public function testTrackFalse()
+    {
+        $this->Email->enableTracking(false);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Track']);
+        $expected = 'no';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Track']);
+    }
+
+    public function testTrackClicksHtmlOnly()
+    {
+        $this->Email->trackClicks();
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Track-Clicks']);
+        $expected = 'htmlonly';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Track-Clicks']);
+    }
+
+    public function testTrackClicksTrue()
+    {
+        $this->Email->trackClicks(true);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Track-Clicks']);
+        $expected = 'yes';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Track-Clicks']);
+    }
+
+    public function testTrackClicksFalse()
+    {
+        $this->Email->trackClicks(false);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Track-Clicks']);
+        $expected = 'no';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Track-Clicks']);
+    }
+
+    public function testTrackOpensTrue()
+    {
+        $this->Email->trackOpens(true);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Track-Opens']);
+        $expected = 'yes';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Track-Opens']);
+    }
+
+    public function testTrackOpenFalse()
+    {
+        $this->Email->trackOpens(false);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Track-Opens']);
+        $expected = 'no';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Track-Opens']);
+    }
+
+    public function testRequireTlsFalse()
+    {
+        $this->Email->requireTls();
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Require-TLS']);
+        $expected = 'false';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Require-TLS']);
+    }
+
+    public function testRequireTlsTrue()
+    {
+        $this->Email->requireTls(true);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Require-TLS']);
+        $expected = 'true';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Require-TLS']);
+    }
+
+    public function testSkipVerificationFalse()
+    {
+        $this->Email->skipVerification();
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Skip-Verification']);
+        $expected = 'false';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Skip-Verification']);
+    }
+
+    public function testSkipVerificationTrue()
+    {
+        $this->Email->skipVerification(true);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Skip-Verification']);
+        $expected = 'true';
+
+        $this->assertEquals($expected, $headers['X-Mailgun-Skip-Verification']);
+    }
+
+    public function testRecipientVars()
+    {
+        $vars = [
+            'email@example.com' => [
+                'var1' => true,
+                'var2' => 'string'
+            ]
+        ];
+
+        $this->Email->setRecipientVars($vars);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Recipient-Variables']);
+        $expected = json_encode($vars);
+        $this->assertEquals($expected, $headers['X-Mailgun-Recipient-Variables']);
+    }
+
+    public function testMailgunVars()
+    {
+        $vars = [
+            'var1' => true,
+            'var2' => 'string'
+        ];
+
+        $this->Email->setMailgunVars($vars);
+
+        $headers = $this->Email->getHeaders(['X-Mailgun-Variables']);
+        $this->assertEquals($vars, $headers['X-Mailgun-Variables']);
+    }
+
+    protected function _setEmailConfig()
+    {
+        TransportFactory::drop('mailgun');
+        TransportFactory::setConfig('mailgun', ['className' => 'Mailgun.Mailgun', 'apiKey' => 'xxxxxxx-test-xxxxxxx', 'domain' => 'xxxxxxx-test.mailgun.org']);
+    }
+}

--- a/tests/TestCase/Mailer/MailgunEmailTest.php
+++ b/tests/TestCase/Mailer/MailgunEmailTest.php
@@ -93,7 +93,7 @@ class MailgunEmailTest extends TestCase
         $this->Email->deliverBy($time);
 
         $headers = $this->Email->getHeaders(['X-Mailgun-Deliver-By']);
-        $expected = $time->format(\DateTimeInterface::RFC822);
+        $expected = $time->format(\DateTimeInterface::RFC2822);
 
         $this->assertEquals($expected, $headers['X-Mailgun-Deliver-By']);
     }

--- a/tests/TestCase/Mailer/Transport/MailgunTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailgunTransportTest.php
@@ -181,8 +181,9 @@ class MailgunTransportTest extends TestCase
         $this->assertStringStartsWith("--$boundary", $reqDataString);
         $this->assertTextContains('Content-Disposition: form-data; name="o:testmode"', $reqDataString);
         $this->assertTextContains('yes', $reqDataString);
-        $this->assertTextContains('Content-Disposition: form-data; name="o:tag"', $reqDataString);
+        $this->assertTextContains('Content-Disposition: form-data; name="o:tag[0]"', $reqDataString);
         $this->assertTextContains('newsletter', $reqDataString);
+        $this->assertTextContains('Content-Disposition: form-data; name="o:tag[1]"', $reqDataString);
         $this->assertTextContains('welcome email', $reqDataString);
     }
 

--- a/tests/TestCase/Mailer/Transport/MailgunTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailgunTransportTest.php
@@ -17,7 +17,10 @@ namespace Mailgun\Test\TestCase\Mailer\Transport;
 
 use Cake\Core\Configure;
 use Cake\Mailer\Email;
+use Cake\Mailer\TransportFactory;
 use Cake\TestSuite\TestCase;
+use Mailgun\Mailer\MailgunEmail;
+use Mailgun\Mailer\Transport\MailgunTransport;
 
 class MailgunTransportTest extends TestCase
 {
@@ -32,6 +35,7 @@ class MailgunTransportTest extends TestCase
     public function testSendEmail()
     {
         $res = $this->_sendEmail();
+        /** @var \Cake\Http\Client\FormData $reqData */
         $reqData = $res['reqData'];
         $boundary = $reqData->boundary();
         $reqDataString = (string)$reqData;
@@ -56,10 +60,12 @@ class MailgunTransportTest extends TestCase
             ->setSubject('Email from CakePHP Mailgun plugin')
             ->send('Hello there, <br> This is an email from CakePHP Mailgun Email plugin.');
 
+        /** @var MailgunTransport $emailInstance */
         $emailInstance = $email->getTransport();
         $requestData = $emailInstance->getRequestData();
         $this->assertEmpty((string)$requestData);
 
+        /** @var \Cake\Http\Client\FormData $reqData */
         $reqData = $res['reqData'];
         $boundary = $reqData->boundary();
         $reqDataString = (string)$reqData;
@@ -89,6 +95,7 @@ class MailgunTransportTest extends TestCase
             ->setSubject('Email from CakePHP Mailgun plugin')
             ->send('Hello there, <br> This is an email from CakePHP Mailgun Email plugin.');
 
+        /** @var \Cake\Http\Client\FormData $reqData */
         $reqData = $res['reqData'];
         $boundary = $reqData->boundary();
         $reqDataString = (string)$reqData;
@@ -121,6 +128,7 @@ class MailgunTransportTest extends TestCase
             ->setSubject('Email from CakePHP Mailgun plugin')
             ->send('Hello there, <br> This is an email from CakePHP Mailgun Email plugin.');
 
+        /** @var \Cake\Http\Client\FormData $reqData */
         $reqData = $res['reqData'];
         $boundary = $reqData->boundary();
         $reqDataString = (string)$reqData;
@@ -142,6 +150,7 @@ class MailgunTransportTest extends TestCase
             ->setSubject('Email from CakePHP Mailgun plugin')
             ->send('Hello there, <br> This is an email from CakePHP Mailgun Email plugin.');
 
+        /** @var \Cake\Http\Client\FormData $reqData */
         $reqData = $res['reqData'];
         $boundary = $reqData->boundary();
         $reqDataString = (string)$reqData;
@@ -153,18 +162,17 @@ class MailgunTransportTest extends TestCase
     public function testSetOption()
     {
         $this->_setEmailConfig();
-        $email = new Email();
-        $email->setProfile(['transport' => 'mailgun']);
+        $email = new MailgunEmail();
 
-        $emailInstance = $email->getTransport();
-        $emailInstance->setOption('testmode', 'yes');
-        $emailInstance->setOption('tag', ['newsletter', 'welcome email']);
+        $email->testMode();
+        $email->setTags(['newsletter', 'welcome email']);
 
         $res = $email->setFrom('from@example.com')
             ->setTo('to@example.com')
             ->setSubject('Email from CakePHP Mailgun plugin')
             ->send();
 
+        /** @var \Cake\Http\Client\FormData $reqData */
         $reqData = $res['reqData'];
         $boundary = $reqData->boundary();
         $reqDataString = (string)$reqData;
@@ -178,46 +186,43 @@ class MailgunTransportTest extends TestCase
         $this->assertTextContains('welcome email', $reqDataString);
     }
 
-    public function testInvalidOptionException()
-    {
-        $this->expectException('Mailgun\Mailer\Exception\MailgunApiException');
-
-        $this->_setEmailConfig();
-        $email = new Email();
-        $email->setProfile(['transport' => 'mailgun']);
-
-        $emailInstance = $email->getTransport();
-        $emailInstance->setOption('foo', 'bar');
-    }
-
-    public function testInvalidOptionValueException()
-    {
-        $this->expectException('Mailgun\Mailer\Exception\MailgunApiException');
-
-        $this->_setEmailConfig();
-        $email = new Email();
-        $email->setProfile(['transport' => 'mailgun']);
-
-        $emailInstance = $email->getTransport();
-        $emailInstance->setOption('testmode', $email);
-    }
-
     public function testSetCustomMessageData()
     {
         $this->_setEmailConfig();
-        $email = new Email();
-        $email->setProfile(['transport' => 'mailgun']);
+        $email = new MailgunEmail();
 
-        $customMessageData = ['foo' => 'bar', 'john' => 'doe'];
-        $emailInstance = $email->getTransport();
-        $emailInstance->setCustomMessageData('custom-data-array', $customMessageData);
-        $emailInstance->setCustomMessageData('my-custom-data', '{"my_message_id": 123}');
+        $email->setMailgunVars(['my-custom-data' => '{"my_message_id": 123}']);
 
         $res = $email->setFrom('from@example.com')
             ->setTo('to@example.com')
             ->setSubject('Email from CakePHP Mailgun plugin')
             ->send();
 
+        /** @var \Cake\Http\Client\FormData $reqData */
+        $reqData = $res['reqData'];
+        $boundary = $reqData->boundary();
+        $reqDataString = (string)$reqData;
+
+        $this->assertNotEmpty($reqDataString);
+        $this->assertStringStartsWith("--$boundary", $reqDataString);
+        $this->assertTextContains('Content-Disposition: form-data; name="v:my-custom-data"', $reqDataString);
+        $this->assertTextContains('{"my_message_id": 123}', $reqDataString);
+    }
+
+    public function testSetCustomMessageDataArray()
+    {
+        $this->_setEmailConfig();
+        $email = new MailgunEmail();
+
+        $customMessageData = ['foo' => 'bar', 'john' => 'doe'];
+        $email->setMailgunVars(['custom-data-array' => $customMessageData]);
+
+        $res = $email->setFrom('from@example.com')
+            ->setTo('to@example.com')
+            ->setSubject('Email from CakePHP Mailgun plugin')
+            ->send();
+
+        /** @var \Cake\Http\Client\FormData $reqData */
         $reqData = $res['reqData'];
         $boundary = $reqData->boundary();
         $reqDataString = (string)$reqData;
@@ -226,35 +231,19 @@ class MailgunTransportTest extends TestCase
         $this->assertStringStartsWith("--$boundary", $reqDataString);
         $this->assertTextContains('Content-Disposition: form-data; name="v:custom-data-array"', $reqDataString);
         $this->assertTextContains(json_encode($customMessageData), $reqDataString);
-        $this->assertTextContains('Content-Disposition: form-data; name="v:my-custom-data"', $reqDataString);
-        $this->assertTextContains('{"my_message_id": 123}', $reqDataString);
-    }
-
-    public function testSetCustomMessageDataException()
-    {
-        $this->expectException('Mailgun\Mailer\Exception\MailgunApiException');
-
-        $this->_setEmailConfig();
-        $email = new Email();
-        $email->setProfile(['transport' => 'mailgun']);
-
-        $emailInstance = $email->getTransport();
-        $emailInstance->setCustomMessageData('my-custom-data', 'invalid data string');
     }
 
     public function testSetRecipientVars()
     {
         $this->_setEmailConfig();
-        $email = new Email();
+        $email = new MailgunEmail();
         $email->setProfile(['transport' => 'mailgun']);
 
         $recipientData = [
             'foo@example.com' => ['name' => 'Foo Bar'],
             'john@example.com' => ['name' => 'John Doe'],
         ];
-        $emailInstance = $email->getTransport();
-        $emailInstance->setRecipientVars($recipientData);
-        $emailInstance->setRecipientVars(json_encode($recipientData));
+        $email->setRecipientVars($recipientData);
 
         $res = $email->setFrom('from@example.com')
             ->setTo('foo@example.com')
@@ -262,6 +251,7 @@ class MailgunTransportTest extends TestCase
             ->setSubject('Email from CakePHP Mailgun plugin')
             ->send();
 
+        /** @var \Cake\Http\Client\FormData $reqData */
         $reqData = $res['reqData'];
         $boundary = $reqData->boundary();
         $reqDataString = (string)$reqData;
@@ -270,18 +260,6 @@ class MailgunTransportTest extends TestCase
         $this->assertStringStartsWith("--$boundary", $reqDataString);
         $this->assertTextContains('Content-Disposition: form-data; name="recipient-variables"', $reqDataString);
         $this->assertTextContains(json_encode($recipientData), $reqDataString);
-    }
-
-    public function testSetRecipientVarsException()
-    {
-        $this->expectException('Mailgun\Mailer\Exception\MailgunApiException');
-
-        $this->_setEmailConfig();
-        $email = new Email();
-        $email->setProfile(['transport' => 'mailgun']);
-
-        $emailInstance = $email->getTransport();
-        $emailInstance->setRecipientVars('string data');
     }
 
     public function testApiExceptions()
@@ -328,25 +306,25 @@ class MailgunTransportTest extends TestCase
 
     protected function _setBlankApiEmailConfig()
     {
-        Email::dropTransport('mailgun');
-        Email::setConfigTransport('mailgun', ['className' => 'Mailgun.Mailgun', 'apiKey' => '', 'domain' => 'xxxxxxx-test.mailgun.org']);
+        TransportFactory::drop('mailgun');
+        TransportFactory::setConfig('mailgun', ['className' => 'Mailgun.Mailgun', 'apiKey' => '', 'domain' => 'xxxxxxx-test.mailgun.org']);
     }
 
     protected function _setBlankDomainEmailConfig()
     {
-        Email::dropTransport('mailgun');
-        Email::setConfigTransport('mailgun', ['className' => 'Mailgun.Mailgun', 'apiKey' => 'xxxxxxx-test-xxxxxxx', 'domain' => '']);
+        TransportFactory::drop('mailgun');
+        TransportFactory::setConfig('mailgun', ['className' => 'Mailgun.Mailgun', 'apiKey' => 'xxxxxxx-test-xxxxxxx', 'domain' => '']);
     }
 
     protected function _setBlankEmailConfig()
     {
-        Email::dropTransport('mailgun');
-        Email::setConfigTransport('mailgun', ['className' => 'Mailgun.Mailgun', 'apiKey' => '', 'domain' => '']);
+        TransportFactory::drop('mailgun');
+        TransportFactory::setConfig('mailgun', ['className' => 'Mailgun.Mailgun', 'apiKey' => '', 'domain' => '']);
     }
 
     protected function _setEmailConfig()
     {
-        Email::dropTransport('mailgun');
-        Email::setConfigTransport('mailgun', ['className' => 'Mailgun.Mailgun', 'apiKey' => 'xxxxxxx-test-xxxxxxx', 'domain' => 'xxxxxxx-test.mailgun.org']);
+        TransportFactory::drop('mailgun');
+        TransportFactory::setConfig('mailgun', ['className' => 'Mailgun.Mailgun', 'apiKey' => 'xxxxxxx-test-xxxxxxx', 'domain' => 'xxxxxxx-test.mailgun.org']);
     }
 }


### PR DESCRIPTION
So with the current setup of modifying the Transport directly this has been causing tons of issues with testing since CakePHP 3.7 has a method to replace the transport with a TestEmailTransport to prevent sending emails. This also causes issues when using `cakephp/debug_kit` but the maintaners did fix it in https://github.com/cakephp/debug_kit/pull/653

I've gone through and created a new `Mailgun\Mailer\MailgunEmail` that implements `Cake\Mailer\Email` and provides convenience methods to set the `X-Mailgun-*` headers. The Transport class will now decode the headers and will add the appropriate part to the `$this->_formData` This will allow for better testing since we no longer need to directly access the Transport when sending emails. This will also allow developers to use their own custom `Email` or the builtin `Cake\Mailer\Email` with the appropriate headers set and still use the `MailgunTransport` I've also gone ahead and fixed all the tests and added `ext-json` to the composer.json since json_encode is used by this plugin. I've also gone ahead and deprecated the `setCustomMessageData`, `setOptions` and `setRecipientVars`

I would recommend tagging this release as `3.1` and removing the `setCustomMessageData`, `setOptions` and `setRecipientVars` towards version 4.0.0 as I've marked them as Deprecated in 4.0.0