### PR TITLE
Ensure that internal state is always reset

### DIFF
--- a/src/Mailer/Transport/MailgunTransport.php
+++ b/src/Mailer/Transport/MailgunTransport.php
@@ -153,16 +153,18 @@ class MailgunTransport extends AbstractTransport
             }
         }
 
-        $apiResponse = $this->_sendEmail();
-        $res = ['apiResponse' => $apiResponse];
+        try {
+            $apiResponse = $this->_sendEmail();
+            $res = ['apiResponse' => $apiResponse];
 
-        if (Configure::read('debug')) {
-            $res['reqData'] = $this->_formData;
+            if (Configure::read('debug')) {
+                $res['reqData'] = $this->_formData;
+            }
+
+            return $res;
+        } finally {
+            $this->_reset();
         }
-
-        $this->_reset();
-
-        return $res;
     }
 
     /**


### PR DESCRIPTION
In cases where an exception occurs when sending the email, the internal state isn't reset. This means that if another email is sent (Or an attempt at retrying the failed email) you get multiple emails concated to each other and being sent to recipients from both emails.