### PR TITLE
Implement a reset inside __clone method to avoid headers duplication

### DIFF
--- a/src/Mailer/Transport/MailgunTransport.php
+++ b/src/Mailer/Transport/MailgunTransport.php
@@ -327,4 +327,14 @@ class MailgunTransport extends AbstractTransport
             }
         }
     }
+
+    /**
+     * clone
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        $this->_reset();
+    }
 }


### PR DESCRIPTION
In Cake4, Mailer class clone transport before executing deliver method, then it restores the transport instance. When MailgunTransport is clone, the FormData instance in _formData property is shared between the two instances (original and clone) so even when _reset is called after sending email, the cloned instance keeps the previous _formData generating emails with multiple to, subject and from headers.

Calling _reset in new instance fixes the issue